### PR TITLE
Switch to class component and switch to tabs

### DIFF
--- a/src/pages/Export.tsx
+++ b/src/pages/Export.tsx
@@ -1,60 +1,85 @@
 import React from 'react';
-import { useAsync } from "react-use";
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { PluginPage, getBackendSrv } from '@grafana/runtime';
-import { TextArea, useStyles2, ErrorWithStack, Spinner, CodeEditor } from '@grafana/ui';
+import { useStyles2, ErrorWithStack, Spinner, CodeEditor, Tab, TabsBar, TabContent } from '@grafana/ui';
 import { testIds } from '../components/testIds';
 import pluginJson from '../plugin.json';
 
-const FileViewer = (props: {filename: string, content: string, format: string}) => {
-  const s = useStyles2(getStyles);
-  return (
-    <>
-      <h2>{props.filename}</h2>
-      <CodeEditor
-        width="100%"
-        height="200px"
-        value={props.content}
-        language={props.format}
-        showLineNumbers={true}
-        showMiniMap={true}
-        readOnly={true}
-      />
-    </>
-  );
-}
-
 interface GeneratedFile {
   name: string;
-  content: string
+  content: string;
+  active: boolean;
 }
 
 interface BackendResponse {
   files: GeneratedFile[];
 }
 
-const FileViewerList = () => {
-  const state = useAsync(async () => {
-    return await getBackendSrv().post<BackendResponse>(`api/plugins/${pluginJson.id}/resources/generate`, {
+class FileViewer extends React.Component {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      exports: {files: []},
+      content: "",
+      loading: true,
+    }
+    this.exportResources();
+  }
+
+  async exportResources() {
+    const exports = await getBackendSrv().post<BackendResponse>(`api/plugins/${pluginJson.id}/resources/generate`, {
       outputFormat: "hcl",
     });
-  });
-
-  if (state.error) {
-    return <ErrorWithStack error={state.error} title={'Unexpected error'} errorInfo={null} />;
-  }
-  if (state.loading) {
-    return <Spinner />;
+    const content = exports.files[0].content
+    exports.files[0].active = true
+    this.setState({exports: exports.files, loading: false, content: content})
   }
 
-  return (
-    <>
-      {state.value!.files.map((file, i) => (<FileViewer key={i} filename={file.name} content={file.content} format="hcl"/>))}
-    </>
-  );
+  render() {
+    //if (this.state.exports.error) {
+    //  return <ErrorWithStack error={exports.error} title={'Unexpected error'} errorInfo={null} />;
+    //}
+    if (this.state.loading) {
+      return <Spinner />;
+    }
+
+    const updateTab = (index: number, self: FileViewer) => {
+      return () => {
+        const files = []
+        let content = ""
+        for (let i in self.state.exports) {
+          const file = self.state.exports[i]
+          file.active = false
+          if (i == index) {
+            file.active = true
+            content = file.content
+          }
+          files.push(file)
+        }
+        this.setState({exports: files, content: content})
+     }
+    }
+    return (
+      <>
+        <TabsBar>
+          {this.state.exports.map((file, i) => (<Tab key={i} active={file.active} label={file.name} onChangeTab={updateTab(i, this)}/>))}
+        </TabsBar>
+        <TabContent>
+        <CodeEditor
+          width="100%"
+          height="500px"
+          value={this.state.content}
+          language="hcl"
+          showLineNumbers={true}
+          showMiniMap={true}
+          readOnly={true}
+        />
+        </TabContent>
+      </>
+    );
+  }
 }
-
 export function ExportPage() {
   const s = useStyles2(getStyles);
   return (
@@ -62,7 +87,7 @@ export function ExportPage() {
       <div data-testid={testIds.exportPage.container}>
         WELCOME TO EXPORT PAGE.
         <div className={s.marginTop}>
-          <FileViewerList/>
+          <FileViewer/>
         </div>
       </div>
     </PluginPage>


### PR DESCRIPTION
This PR switches from a function component to a full class react component. This simply makes
the logic (e.g. `render()`) clearer.

It also moves away from a list of `<h2>` followed by `<CodeEditor>` to a single code editor, with content switched by tabs.
