### PR TITLE
Remember resource type selection when changing options

### DIFF
--- a/src/components/OptionsSelector.tsx
+++ b/src/components/OptionsSelector.tsx
@@ -44,9 +44,8 @@ export function OptionsSelector(props: OptionsSelectorProps) {
   }, [target, format])
 
   useEffect(() => {
-    console.log("GETTING RESOURCE TYPES")
-    getResourceTypes(target, format, setResourceTypes)
-  }, [target, format]);
+    getResourceTypes(target, format, resourceTypes, setResourceTypes)
+  }, [target, format, resourceTypes]);
 
   useEffect(() => {
     if (resourceTypes.filter(r => r.selected).length === 0) {

--- a/src/hooks/resourceTypes.tsx
+++ b/src/hooks/resourceTypes.tsx
@@ -3,15 +3,27 @@ import { getBackendSrv } from '@grafana/runtime';
 import pluginJson from "../plugin.json"
 import { ResourceType, ResourceTypeResponse } from "../types/resourceTypes";
 
-export const getResourceTypes = async (target: string, outputFormat: string, callback: any) => {
+export const getResourceTypes = async (target: string, outputFormat: string, currentResourceTypes: ResourceType[], callback: any) => {
     try {
         const types = await getBackendSrv().get<ResourceTypeResponse>(`api/plugins/${pluginJson.id}/resources/resource-types`, { target: target, outputFormat: outputFormat })
-        const typeList: ResourceType[] = []
-        types.resources.forEach(type => {
-            type.selected = true
-            typeList.push(type)
+
+        // Re-select the resource types that were previously selected
+        // If the names don't match, reset to all selected
+        const currentResourceTypesMap = new Map<string, ResourceType>()
+        let matchedName = false
+        currentResourceTypes.forEach(type => {
+            currentResourceTypesMap.set(type.name, type)
         })
-        callback(typeList)
+        types.resources.forEach(t => {
+            if (currentResourceTypesMap.has(t.name)) {
+                matchedName = true
+                t.selected = currentResourceTypesMap.get(t.name)!.selected
+            }
+        })
+        if (!matchedName) {
+            types.resources.forEach(t => t.selected = true)
+        }
+        callback(types.resources)
     } catch (err) {
         console.log(err)
     }


### PR DESCRIPTION
Depends on https://github.com/grafana/grafana-resources-exporter-plugin/pull/30 
Currently, when changing from one format to another, the resource types are fetched again This resets the selection completely. 
With this PR, the selection is kept, unless the types change completely (ex: going from TF to Grizzly or vice versa)