### PR TITLE
Expose JSON Data types globally

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,8 +1,9 @@
 import { AppPlugin } from '@grafana/data';
 import { App } from './components/App';
 import { AppConfig } from './components/AppConfig';
+import { ExporterPluginMetaJSONData } from 'types/pluginData';
 
-export const plugin = new AppPlugin<{}>().setRootPage(App).addConfigPage({
+export const plugin = new AppPlugin<ExporterPluginMetaJSONData>().setRootPage(App).addConfigPage({
   title: 'Configuration',
   icon: 'cog',
   body: AppConfig,

--- a/src/types/pluginData.ts
+++ b/src/types/pluginData.ts
@@ -1,0 +1,24 @@
+import { AppRootProps as BaseAppRootProps, AppPluginMeta, PluginConfigPageProps } from '@grafana/data';
+
+
+export type ExporterPluginMetaJSONData = {
+    grafanaUrl: string;
+    grafanaIsCloudStack: boolean;
+    smUrl: string;
+    oncallUrl: string;
+    cloudOrg: string;
+};
+
+export type ExporterPluginMetaSecureJSONData = {
+    grafanaServiceAccountToken: string;
+    smToken: string;
+    oncallToken: string;
+    cloudAccessPolicyToken: string;
+};
+
+export type AppRootProps = BaseAppRootProps<ExporterPluginMetaJSONData>;
+
+export type ExporterAppPluginMeta = AppPluginMeta<ExporterPluginMetaJSONData>;
+export type ExporterPluginConfigPageProps = PluginConfigPageProps<ExporterAppPluginMeta>;
+
+


### PR DESCRIPTION
Have the data be available everywhere by sharing the types. 
This will make an init page easier to implement With actual types, I was able to remove some of the duplicated code in the AppConfig and make it a bit cleaner as well