### PR TITLE
Easier configuration for new users

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -22,11 +22,12 @@
         "import\\s*.*\".*?\""
     ],
     "words": [
-        "grafana",
+        "crossplane",
         "datasource",
         "datasources",
-        "crossplane",
+        "grafana",
         "oncall",
-        "resourcesexporter"
+        "resourcesexporter",
+        "serviceaccounts"
     ]
 }

--- a/provisioning/plugins/apps.yaml
+++ b/provisioning/plugins/apps.yaml
@@ -5,5 +5,4 @@ apps:
     org_id: 1
     org_name: 'grafana'
     disabled: false
-    jsonData:
-      grafanaUrl: http://localhost:3000
+

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { AppRootProps } from '@grafana/data';
-import { ExportPage } from '../../pages';
+import { ExportPage, InitPage } from '../../pages';
+import { AppRootProps } from 'types/pluginData';
 
 export function App(props: AppRootProps) {
+
+  const initPage = InitPage(props);
   return (
-     <Routes>
-       <Route path="*" element={<ExportPage />} />
-     </Routes>
-   );
- }
+    <Routes>
+      <Route path="/" element={initPage} />
+      <Route path="/export" element={<ExportPage />} />
+    </Routes>
+  );
+}

--- a/src/pages/Init.tsx
+++ b/src/pages/Init.tsx
@@ -1,0 +1,25 @@
+import { PluginPage } from "@grafana/runtime";
+import { Button } from "@grafana/ui";
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { AppRootProps } from "types/pluginData";
+
+export const InitPage = (plugin: AppRootProps) => {
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (plugin.meta !== undefined && plugin.meta.jsonData && plugin.meta.jsonData.initialized === true) {
+            navigate('export');
+        }
+    }, [navigate, plugin.meta]);
+
+    return (
+        <PluginPage>
+            <div>
+                The plugin has not been configured yet. Click the button below to configure the plugin.
+                <br />
+                <Button onClick={() => navigate('/plugins/' + plugin.meta.id)} size="lg">Configure Plugin Here</Button>
+            </div>
+        </PluginPage >
+    );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,1 +1,2 @@
+export { InitPage } from './Init';
 export { ExportPage } from './Export';

--- a/src/types/pluginData.ts
+++ b/src/types/pluginData.ts
@@ -7,6 +7,7 @@ export type ExporterPluginMetaJSONData = {
     smUrl: string;
     oncallUrl: string;
     cloudOrg: string;
+    initialized: boolean;
 };
 
 export type ExporterPluginMetaSecureJSONData = {


### PR DESCRIPTION
This is not in an optimal state as I'd need to consult with some app experts to know what's possible but it's good enough for release

Improvements:
- If the plugin is not configured, show a simple page that points to the config page
- Default the plugin URL to the current HOST
- Remove the "is cloud" checkbox
- Add links in the config page that shows the user where to find the various urls and tokens