### PR TITLE
Add support for non-critical errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace github.com/hashicorp/terraform-exec v0.21.0 => github.com/hrmsk66/terraf
 require (
 	github.com/grafana/grafana-plugin-sdk-go v0.236.0
 	github.com/grafana/grizzly v0.4.4
-	github.com/grafana/terraform-provider-grafana/v3 v3.3.1-0.20240710125908-ae20cce50e98
+	github.com/grafana/terraform-provider-grafana/v3 v3.4.0
 )
 
 require (
@@ -62,7 +62,7 @@ require (
 	github.com/grafana/amixr-api-go-client v0.0.12 // indirect
 	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20240322153219-42c6a1d2bcab // indirect
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20240523010106-657d101fcbd9 // indirect
-	github.com/grafana/machine-learning-go-client v0.7.0 // indirect
+	github.com/grafana/machine-learning-go-client v0.8.0 // indirect
 	github.com/grafana/otel-profiling-go v0.5.1 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.7 // indirect
 	github.com/grafana/slo-openapi-client/go v0.0.0-20240626093634-e6741482b090 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/grafana/grafana-plugin-sdk-go v0.236.0 h1:SmBO0KuAwbKwp68sVrrMnpWhqkD
 github.com/grafana/grafana-plugin-sdk-go v0.236.0/go.mod h1:diZikRjMwbyCDyKpieBK0MpSmHU4SNtvmW/iDfTXzyQ=
 github.com/grafana/grizzly v0.4.4 h1:mRB91XucUK6wcxsznlXFN4JfN2A/7wq3R07Ar8xgU4Y=
 github.com/grafana/grizzly v0.4.4/go.mod h1:0LpwI+cKlIjq4adLbwA8oxOl4BjZ303fh8cexi37rKU=
-github.com/grafana/machine-learning-go-client v0.7.0 h1:yiRBg8rCNbHh9BURa+vtZ8ItRYvabbdYAtsAOfxoFPI=
-github.com/grafana/machine-learning-go-client v0.7.0/go.mod h1:bKsLSJTreH7HXaL2FJnnrliMuP0L8XwMkXte6AgwFFg=
+github.com/grafana/machine-learning-go-client v0.8.0 h1:N8+0f5aFM/umVJWvlJkJy9McVIp9MIBUtuNruug94II=
+github.com/grafana/machine-learning-go-client v0.8.0/go.mod h1:9xRIoH6Y6RubuCPNjLfpckE/fLVe9dazg3HSLI1ARAU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.7 h1:C11j63y7gymiW8VugJ9ZW0pWfxTZugdSJyC48olk5KY=
@@ -161,8 +161,8 @@ github.com/grafana/synthetic-monitoring-agent v0.24.3 h1:+xscAsGZtWTNTNDxdYqqcz4
 github.com/grafana/synthetic-monitoring-agent v0.24.3/go.mod h1:CJQmPtKRcJMjb/sDe6fDA4vyS2qFPElu0szI33nKlzk=
 github.com/grafana/synthetic-monitoring-api-go-client v0.8.0 h1:Tm4MtwwYmPNInGfnj66l6j6KOshMkNV4emIVKJdlXMg=
 github.com/grafana/synthetic-monitoring-api-go-client v0.8.0/go.mod h1:TGaywTdL2Z+PJhpWzJEmJFRF5K55vKz2f39mWY/GvV8=
-github.com/grafana/terraform-provider-grafana/v3 v3.3.1-0.20240710125908-ae20cce50e98 h1:4wQW8OjAl2nW8s7IDUfI3LTJIufNCdlOVbqg6QlDlNk=
-github.com/grafana/terraform-provider-grafana/v3 v3.3.1-0.20240710125908-ae20cce50e98/go.mod h1:w3mWy3VvonbMG2iXL2fsC5hilVcWRtpiZlnVuiDDxfI=
+github.com/grafana/terraform-provider-grafana/v3 v3.4.0 h1:eDMAHml+wasPP/zA9nwUS4v1tEtYIUo7SpSMT1cWizk=
+github.com/grafana/terraform-provider-grafana/v3 v3.4.0/go.mod h1:GF/LGr6ypu4wQn6t3JcF7W+i2FaryOg6LD6vkhWhy9I=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 h1:qnpSQwGEnkcRpTqNOIR6bJbR0gAorgP9CSALpRcKoAA=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod h1:lXGCsh6c22WGtjr+qGHj1otzZpV/1kwTMAqkwZsnWRU=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 h1:pRhl55Yx1eC7BZ1N+BBWwnKaMyD8uC+34TLdndZMAKk=

--- a/src/pages/Export.tsx
+++ b/src/pages/Export.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { PluginPage, getBackendSrv, isFetchError } from '@grafana/runtime';
-import { ErrorWithStack, ToolbarButton, ToolbarButtonRow } from '@grafana/ui';
+import { Alert, ErrorWithStack, ToolbarButton, ToolbarButtonRow } from '@grafana/ui';
 import { GeneratedFile, GenerateRequest, GenerateResponse } from "../types/generator";
 import { saveAs } from 'file-saver';
 import JSZip from "jszip";
@@ -11,7 +11,8 @@ import { OptionsSelector } from 'components/OptionsSelector';
 export function ExportPage() {
   const [files, setFiles] = useState<GeneratedFile[]>([])
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<{ title: string, error: Error, info: React.ErrorInfo | null } | undefined>(undefined)
+  const [error, setError] = useState<{ title: string, error: Error } | undefined>(undefined)
+  const [warning, setWarning] = useState<{ title: string, error: Error } | undefined>(undefined)
   const [options, setOptions] = useState<GenerateRequest | undefined>(undefined)
   const [optionsCollapsed, setOptionsCollapsed] = useState(false)
 
@@ -43,7 +44,7 @@ export function ExportPage() {
   </div>
 
   if (error) {
-    content = <ErrorWithStack title={error.title} error={error.error} errorInfo={error.info} />;
+    content = <ErrorWithStack title={error.title} error={error.error} errorInfo={null} />;
   } else if (files.length > 0) {
     content = <ResultViewer height={editorHeight + 'px'} files={files} />
   } else if (loading) {
@@ -55,14 +56,17 @@ export function ExportPage() {
     try {
       const exports = await getBackendSrv().post<GenerateResponse>(`api/plugins/${pluginJson.id}/resources/generate`, options, { showErrorAlert: false });
       setFiles(exports.files || [{ name: "Result", content: "No resources were found" }])
+      if (exports.warnings.length > 0) {
+        setWarning({ title: "Some resources could not be exported", error: new Error(exports.warnings.join('\n')) })
+      }
       setError(undefined)
     } catch (err) {
       if (err instanceof Error) {
-        setError({ title: err.message, error: err, info: null })
+        setError({ title: err.message, error: err })
       } else if (isFetchError(err)) {
-        setError({ title: err.statusText!, error: new Error(err.data?.message), info: null })
+        setError({ title: err.statusText!, error: new Error(err.data?.message) })
       } else {
-        setError({ title: "Unexpected Error", error: new Error(`${err}`), info: null })
+        setError({ title: "Unexpected Error", error: new Error(`${err}`) })
       }
     }
     setLoading(false)
@@ -95,6 +99,11 @@ export function ExportPage() {
 
   return (
     <PluginPage actions={actions}>
+      {warning &&
+        <Alert title={warning.title} onRemove={() => setWarning(undefined)}>
+          {warning.error.message}
+        </Alert>
+      }
       <div ref={topRef} style={optionsCollapsed ? { display: 'none' } : {}}>
         <OptionsSelector onChange={setOptions} />
       </div>

--- a/src/types/generator.ts
+++ b/src/types/generator.ts
@@ -11,4 +11,5 @@ export interface GenerateRequest {
 
 export interface GenerateResponse {
     files: GeneratedFile[];
+    warnings: string[];
 }


### PR DESCRIPTION
If a single resource fails to export, it shouldn't crash the whole process. The user can just close the warning and carry on

Example of badly configured SM creds:
![image](https://github.com/user-attachments/assets/9932279e-f820-4701-b32a-91273e8c6ae2)
