### PR TITLE
Fix configuration save issue

### DIFF
--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -29,11 +29,13 @@ export const AppConfig = ({ plugin }: Props) => {
       cloudOrg: '',
       initialized: false,
     },
+    // Fields that were set previously should be set to undefined to avoid wiping them out.
+    // Undefined fields will be omitted from the payload sent to the backend, so they won't be updated.
     secureJsonData: {
-      grafanaServiceAccountToken: '',
-      smToken: '',
-      oncallToken: '',
-      cloudAccessPolicyToken: '',
+      grafanaServiceAccountToken: !secureJsonFields?.grafanaServiceAccountToken ? '' : undefined,
+      smToken: !secureJsonFields?.smToken ? '' : undefined,
+      oncallToken: !secureJsonFields?.oncallToken ? '' : undefined,
+      cloudAccessPolicyToken: !secureJsonFields?.cloudAccessPolicyToken ? '' : undefined,
     },
     secureJsonDataSet: secureJsonFields || {},
   });

--- a/src/types/pluginData.ts
+++ b/src/types/pluginData.ts
@@ -11,10 +11,10 @@ export type ExporterPluginMetaJSONData = {
 };
 
 export type ExporterPluginMetaSecureJSONData = {
-    grafanaServiceAccountToken: string;
-    smToken: string;
-    oncallToken: string;
-    cloudAccessPolicyToken: string;
+    grafanaServiceAccountToken?: string;
+    smToken?: string;
+    oncallToken?: string;
+    cloudAccessPolicyToken?: string;
 };
 
 export type AppRootProps = BaseAppRootProps<ExporterPluginMetaJSONData>;


### PR DESCRIPTION
Right now, when you save configs, it wipes out secure fields that weren't configured in the current sessions 
To fix that, we can omit those fields when sending the payload to the backend. This is a regression (caused by myself), so I added a comment (better would be a test, but the test framework isn't set-up