### PR TITLE
Fix flashing init screen

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -6,10 +6,10 @@ import { AppRootProps } from 'types/pluginData';
 export function App(props: AppRootProps) {
 
   const initPage = InitPage(props);
+  const exportPage = <ExportPage />;
   return (
     <Routes>
-      <Route path="/" element={initPage} />
-      <Route path="/export" element={<ExportPage />} />
+      <Route path="/*" element={props.meta.jsonData?.initialized ? exportPage : initPage} />
     </Routes>
   );
 }

--- a/src/pages/Init.tsx
+++ b/src/pages/Init.tsx
@@ -1,18 +1,11 @@
 import { PluginPage } from "@grafana/runtime";
 import { Button } from "@grafana/ui";
-import React, { useEffect } from "react";
+import React from "react";
 import { useNavigate } from "react-router-dom";
 import { AppRootProps } from "types/pluginData";
 
 export const InitPage = (plugin: AppRootProps) => {
     const navigate = useNavigate();
-
-    useEffect(() => {
-        if (plugin.meta !== undefined && plugin.meta.jsonData && plugin.meta.jsonData.initialized === true) {
-            navigate('export');
-        }
-    }, [navigate, plugin.meta]);
-
     return (
         <PluginPage>
             <div>


### PR DESCRIPTION
The init page is currently shown every time and redirects to the export page. Unfortunately, the init page still visibly flashes. 

With this PR, it shouldn't be shown at all if the plugin has been initialized