### PR TITLE
docs(readme): add archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Grafana Resources Exporter
 
+> [!NOTE]
+> This project has been archived and is no longer actively developed. The ideas behind it are slowly being incorporated into Grafana natively.
+
 The resources exporter is a Grafana App Plugin that allows users to export resources from their instance or Grafana Cloud account as Terraform, Grizzly or Crossplane resource definitions.
 
 ## Terraform Config Generation


### PR DESCRIPTION
## Summary
- Add a note callout to the README explaining that this project has been archived and is no longer actively developed, with the ideas being incorporated into Grafana natively.